### PR TITLE
Add Codex skill with usage guidance and drawing templates

### DIFF
--- a/.agents/skills/alchemist/SKILL.md
+++ b/.agents/skills/alchemist/SKILL.md
@@ -38,7 +38,7 @@ compose molecules from fragments connected by links.
 |---|---|
 | `fragment(mol, name:, links:, lewis:, ...)` | A chemical symbol / group. String notation: `"C_6H_12O_6"`, `"Fe^{2+}"`, `$CH_4$` (equation) |
 | `hook(name)` | Named anchor point for links |
-| `single(double, triple, ...)` | Bond between fragments — see Links section |
+| `single()` / `double()` / `triple()` / `cram-*()` / `plus()` | Bonds between fragments — see Links section |
 | `branch(body)` | Side chain off a fragment (body starts with a link) |
 | `cycle(faces, body)` | Regular polygon-shaped ring (faces >= 3) |
 | `parenthesis(body, l:"(", r:")", ...)` | Polymer or resonance brackets |

--- a/.agents/skills/alchemist/SKILL.md
+++ b/.agents/skills/alchemist/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: alchemist
+description: >
+  Draw chemical skeletal formulas (structural formulas) in Typst using the alchemist package.
+  Use when Codex needs to create molecular structure diagrams, organic chemistry drawings,
+  Lewis structures, reaction schemes, resonance structures, or polymer representations in Typst
+  documents. Integrates with CeTZ for additional canvas drawing. Supports: (1) molecules with
+  fragments and bonds (single/double/triple/cram), (2) branches and cycles, (3) charges and
+  Lewis structures, (4) reaction operators, (5) polymer/resonance parenthesis, (6) hiding parts
+  of molecules for presentations. The package is based on chemfig conventions.
+---
+
+# Alchemist – Skeletal Formula Drawing for Typst
+
+Alchemist draws chemical structures inside a `skeletize` block using CeTZ. Import once, then
+compose molecules from fragments connected by links.
+
+```typ
+#import "@preview/alchemist:0.1.10": *
+
+#skeletize({
+  fragment("A")
+  single()
+  fragment("B")
+})
+```
+
+## Core workflow
+
+1. **`skeletize(body)`** — wraps everything in a CeTZ canvas.  
+2. Inside the body, list elements in drawing order: fragments, links, branches, cycles, etc.  
+3. Links connect the **previous** fragment (or anchor) to the **next** fragment.  
+4. Branches and cycles group elements with sub-layout.
+
+### Main elements
+
+| Element | Purpose |
+|---|---|
+| `fragment(mol, name:, links:, lewis:, ...)` | A chemical symbol / group. String notation: `"C_6H_12O_6"`, `"Fe^{2+}"`, `$CH_4$` (equation) |
+| `hook(name)` | Named anchor point for links |
+| `single(double, triple, ...)` | Bond between fragments — see Links section |
+| `branch(body)` | Side chain off a fragment (body starts with a link) |
+| `cycle(faces, body)` | Regular polygon-shaped ring (faces >= 3) |
+| `parenthesis(body, l:"(", r:")", ...)` | Polymer or resonance brackets |
+| `operator(op, margin:)` | Separator between molecules (e.g. reaction arrow) |
+| `hide(bounds:, body)` | Visually suppress part of the drawing for animations |
+
+## Fragment notation
+
+Fragments are the core atoms/groups. They can be strings or math equations.
+
+**String notation rules** — consecutive capital letters split into separate atoms:
+- `"H_2O"` renders as H2O
+- `"C^5_4"` renders as C with superscript 5 and subscript 4
+- `"A'"` / `"A''"` renders primed atoms
+- `"C_6H_12O_6"` renders a multi-atom molecule (each token auto-spaced)
+
+**Equation notation** — more flexible, supports arbitrary structure:
+```typ
+fragment($C(C H_3)_3$)  // tert-butyl group
+```
+
+**Parameters:**
+- `name:` — identifier for linking (auto-generated if omitted)
+- `links:` — dict mapping target names to link functions (see cross-linking)
+- `lewis:` — list of lewis-dot decorations
+- `vertical:` — stack atoms vertically instead of horizontally
+- `ignore-charge:` — excludes charge atoms from link connection points
+- `colors:` — single color or list of colors for each atom group
+
+## Links (bonds)
+
+Links connect the **current drawing position** to the **next fragment**. Each link function
+accepts named arguments that override config defaults.
+
+| Link | Appearance |
+|---|---|
+| `single()` | Single line |
+| `double()` | Double line (configurable `gap`, `offset: "left"/"right"/"center"`) |
+| `triple()` | Triple line |
+| `cram-filled-right()` / `cram-filled-left()` | Solid wedge (stereochemistry) |
+| `cram-hollow-right()` / `cram-hollow-left()` | Hollow wedge |
+| `cram-dashed-right()` / `cram-dashed-left()` | Dashed wedge |
+| `plus()` | Plus sign between fragments |
+
+## Branches
+
+A branch starts from the current fragment and draws a side chain. The first element must be a link.
+
+```typ
+branch({
+  single(angle: 1)   // angle multiplier of angle-increment (default 45deg)
+  fragment("OH")
+})
+```
+
+## Cycles
+
+Create regular polygon rings. The body alternates links and fragments.
+
+```typ
+cycle(6, {
+  single()
+  fragment("")
+  single()
+  fragment("")
+  single()
+  fragment("")
+})
+```
+
+## Lewis structures
+
+Decorate a fragment with electron representations via the `lewis:` parameter.
+
+```typ
+fragment("O", lewis: (
+  lewis-single(offset: "top"),
+  lewis-double(angle: 90deg),
+  lewis-line(angle: 45deg),
+  lewis-rectangle(angle: 180deg),
+))
+```
+
+| Lewis element | Description |
+|---|---|
+| `lewis-single(offset:, gap:)` | Single electron dot |
+| `lewis-double(gap:)` | Two electron dots (lone pair) |
+| `lewis-line(length:)` | Line through a dot pair |
+| `lewis-rectangle(height:, width:)` | Rectangular lone pair marker |
+
+## Cross-linking fragments
+
+Use named fragments and the `links:` parameter to draw bonds between non-adjacent atoms.
+
+```typ
+fragment(name: "A", "A")
+single()
+fragment("B")
+branch({
+  single()
+  fragment(name: "X", "X")
+})
+single()
+fragment("C", links: (
+  "A": double(stroke: red),
+  "X": single(),
+))
+```
+
+## Configuration
+
+Use `skeletize-config(default-config)` to create a pre-configured drawer.
+
+```typ
+#let draw-molecule = skeletize-config((
+  angle-increment: 30deg,
+  base-angle: 90deg,
+  single: (stroke: blue),
+))
+
+#draw-molecule({
+  fragment("A")
+  single()
+  fragment("B")
+})
+```
+
+Available config keys with defaults: see [references/api.md](references/api.md).
+
+## CeTZ integration
+
+Alchemist renders on a CeTZ canvas. Mix raw CeTZ drawing commands inside `skeletize`:
+
+```typ
+#skeletize({
+  import cetz.draw: *
+  single(absolute: 30deg, name: "l1")
+  hobby("l1.start", ("l1.end", 0.5, 90deg, "l1.start"), mark: (end: ">"))
+  fragment("X")
+})
+```
+
+## Low-level drawing
+
+Use `draw-skeleton(config:, name:, body)` to draw without the canvas wrapper — useful when
+embedding inside an existing CeTZ canvas.
+
+## Touying integration
+
+Alchemist provides automatic touying bindings for slide reveal/hide effects.
+
+See [references/api.md](references/api.md) for the full API reference and
+[references/patterns.md](references/patterns.md) for common molecule templates.

--- a/.agents/skills/alchemist/agents/openai.yaml
+++ b/.agents/skills/alchemist/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Alchemist Chemistry Drawing"
+  short_description: "Draw chemical skeletal formulas in Typst with alchemist"
+  default_prompt: "Use $alchemist to draw chemical molecule structures in Typst documents with bonds, fragments, cycles, and Lewis structures."

--- a/.agents/skills/alchemist/references/api.md
+++ b/.agents/skills/alchemist/references/api.md
@@ -8,12 +8,12 @@
 
 ## Core functions
 
-### `skeletize(debug, background, config, body)`
+### `skeletize(debug:, background:, config:, body)`
 Wraps molecule drawing in a CeTZ canvas.
-- `debug` (bool, default false) — shows bounding boxes and anchor points
-- `background` (none, color) — canvas background
-- `config` (dictionary) — overrides default configuration
-- `body` — drawing commands inside `{}`
+- `body` — drawing commands inside `{}` (positional argument)
+- `debug:` (bool, default false) — shows bounding boxes and anchor points
+- `background:` (none, color) — canvas background
+- `config:` (dictionary) — overrides default configuration
 
 ### `skeletize-config(default-config) -> function`
 Returns a pre-configured skeletize function.
@@ -22,7 +22,7 @@ Returns a pre-configured skeletize function.
 #draw({ fragment("A") single() fragment("B") })
 ```
 
-### `draw-skeleton(config, name, mol-anchor, body)`
+### `draw-skeleton(config:, name:, mol-anchor:, body)`
 Low-level draw without canvas wrapper. Use inside an existing CeTZ canvas.
 
 ### `draw-skeleton-config(default-config) -> function`
@@ -35,14 +35,14 @@ Passthrough function (placeholder for future use).
 
 ## Fragment
 
-### `fragment(mol, name, links, lewis, vertical, ignore-charge, colors)`
-- `mol` (string or equation) — chemical formula. String splits by capital letters
-- `name` (string, optional) — identifier for cross-linking
-- `links` (dict) — maps target fragment/hook names to link functions
-- `lewis` (array) — Lewis decoration elements
-- `vertical` (bool, default false) — stack atoms vertically
-- `ignore-charge` (bool, default false) — exclude charges from link connections
-- `colors` (color or array) — color(s) for atom groups
+### `fragment(mol, name:, links:, lewis:, vertical:, ignore-charge:, colors:)`
+- `mol` (string or equation) — chemical formula. String splits by capital letters (positional argument)
+- `name:` (string, optional) — identifier for cross-linking
+- `links:` (dict) — maps target fragment/hook names to link functions
+- `lewis:` (array) — Lewis decoration elements
+- `vertical:` (bool, default false) — stack atoms vertically
+- `ignore-charge:` (bool, default false) — exclude charges from link connections
+- `colors:` (color or array) — color(s) for atom groups
 
 **String notation:**
 - `"H_2O"`, `"C_6H_12O_6"` — subscripts with `_`
@@ -124,9 +124,10 @@ Accepts `align:` argument to force alignment to the previous link angle.
 
 ## Parenthesis
 
-### `parenthesis(body, l, r, align, resonance, height, yoffset, xoffset, right, tr, br)`
+### `parenthesis(body, l:, r:, align:, resonance:, height:, yoffset:, xoffset:, right:, tr:, br:)`
 Enclose a group in brackets. Used for polymers and resonance structures.
 
+- `body` — drawing commands inside `{}` (positional argument, should come first)
 - `l:` (string) — left parenthesis character (default `"("`)
 - `r:` (string) — right parenthesis character (default `")"`)
 - `align:` (bool, default true) — auto-size and align
@@ -140,9 +141,10 @@ Enclose a group in brackets. Used for polymers and resonance structures.
 
 ## Operator
 
-### `operator(op, name, margin)`
+### `operator(op, name:, margin:)`
 Separate molecules within the same skeletize block. Resets drawing position.
-- `op:` (content, string, or none) — the displayed operator
+- `op` (content, string, or none) — the displayed operator (positional argument)
+- `name:` (string, optional) — identifier for the operator
 - `margin:` (length, default 1em) — spacing
 
 ```typ
@@ -160,24 +162,25 @@ Named anchor point for links. Place at a position to create a connection target.
 
 ## Hide
 
-### `hide(bounds, body)`
+### `hide(bounds:, body)`
 Visually suppress part of the drawing. Hidden elements still occupy bounding box space and remain linkable.
 - `bounds:` (bool, default true) — preserve bounding box when true
+- `body` — drawing commands inside `{}` (positional argument)
 
 ---
 
 ## Lewis structures
 
-### `lewis-single(angle, radius, offset, gap, stroke, fill)`
+### `lewis-single(angle:, radius:, offset:, gap:, stroke:, fill:)`
 Single electron dot. `offset:` is `"top"`, `"bottom"`, or `"center"`.
 
-### `lewis-double(angle, radius, gap, stroke, fill)`
+### `lewis-double(angle:, radius:, gap:, stroke:, fill:)`
 Two electron dots (lone pair).
 
-### `lewis-line(angle, length, stroke)`
+### `lewis-line(angle:, length:, stroke:)`
 Line representing a shared electron pair.
 
-### `lewis-rectangle(angle, stroke, fill, height, width)`
+### `lewis-rectangle(angle:, stroke:, fill:, height:, width:)`
 Rectangular lone pair marker.
 
 ---

--- a/.agents/skills/alchemist/references/api.md
+++ b/.agents/skills/alchemist/references/api.md
@@ -1,0 +1,264 @@
+# Alchemist API Reference
+
+## Import
+
+```typ
+#import "@preview/alchemist:0.1.10": *
+```
+
+## Core functions
+
+### `skeletize(debug, background, config, body)`
+Wraps molecule drawing in a CeTZ canvas.
+- `debug` (bool, default false) — shows bounding boxes and anchor points
+- `background` (none, color) — canvas background
+- `config` (dictionary) — overrides default configuration
+- `body` — drawing commands inside `{}`
+
+### `skeletize-config(default-config) -> function`
+Returns a pre-configured skeletize function.
+```typ
+#let draw = skeletize-config((angle-increment: 30deg))
+#draw({ fragment("A") single() fragment("B") })
+```
+
+### `draw-skeleton(config, name, mol-anchor, body)`
+Low-level draw without canvas wrapper. Use inside an existing CeTZ canvas.
+
+### `draw-skeleton-config(default-config) -> function`
+Pre-configured draw-skeleton.
+
+### `hide-drawables(elements)`
+Passthrough function (placeholder for future use).
+
+---
+
+## Fragment
+
+### `fragment(mol, name, links, lewis, vertical, ignore-charge, colors)`
+- `mol` (string or equation) — chemical formula. String splits by capital letters
+- `name` (string, optional) — identifier for cross-linking
+- `links` (dict) — maps target fragment/hook names to link functions
+- `lewis` (array) — Lewis decoration elements
+- `vertical` (bool, default false) — stack atoms vertically
+- `ignore-charge` (bool, default false) — exclude charges from link connections
+- `colors` (color or array) — color(s) for atom groups
+
+**String notation:**
+- `"H_2O"`, `"C_6H_12O_6"` — subscripts with `_`
+- `"Fe^{2+}"`, `"C^5"` — superscripts with `^`
+- `"A'"`, `"A''"` — primes
+- `"C^-"` — charges (superscript `-` or `+`)
+
+**Equation notation:** Use math mode for complex groups.
+```typ
+fragment($C(C H_3)_3$)
+```
+
+---
+
+## Links (bonds)
+
+All links accept:
+- `angle:` (int — multiplier of `angle-increment`, defaults to 0)
+- `absolute:` (angle) — absolute angle in degrees
+- `relative:` (angle) — relative angle from current direction
+- `name:` (string) — identifier
+- `over:` (string or dict) — creates an overpass for crossing bonds
+
+### `single(stroke)`
+
+### `double(gap, offset, offset-coeff, stroke)`
+- `offset:` — `"left"`, `"right"`, or `"center"` (default `"center"`)
+- `offset-coeff:` (0–1) — fraction of line length used for offset
+
+### `triple(gap, stroke)`
+
+### `cram-filled-right(stroke, fill, base-length)`
+### `cram-filled-left(stroke, fill, base-length)`
+### `cram-hollow-right(stroke, fill, base-length)`
+### `cram-hollow-left(stroke, fill, base-length)`
+
+### `cram-dashed-right(stroke, dash-gap, base-length, tip-length)`
+### `cram-dashed-left(stroke, dash-gap, base-length, tip-length)`
+
+### `plus(fill, size, stroke)`
+
+---
+
+## Branch
+
+### `branch(body)`
+Side chain off a fragment. Body must start with a link.
+
+Angle argument on the first link sets the branch direction:
+```typ
+branch({
+  single(angle: 1)    // 45deg (1x angle-increment)
+  fragment("OH")
+})
+```
+
+---
+
+## Cycle
+
+### `cycle(faces, body)`
+Regular polygon ring with `faces` vertices (minimum 3).
+
+The body alternates links and fragments. For a regular ring the fragments can be empty:
+```typ
+cycle(6, {
+  single()
+  fragment("")
+  single()
+  fragment("")
+  single()
+  fragment("")
+})
+```
+
+Accepts `align:` argument to force alignment to the previous link angle.
+
+---
+
+## Parenthesis
+
+### `parenthesis(body, l, r, align, resonance, height, yoffset, xoffset, right, tr, br)`
+Enclose a group in brackets. Used for polymers and resonance structures.
+
+- `l:` (string) — left parenthesis character (default `"("`)
+- `r:` (string) — right parenthesis character (default `")"`)
+- `align:` (bool, default true) — auto-size and align
+- `resonance:` (bool) — resonance mode (separated from neighbors)
+- `height:` (length) — manual height
+- `yoffset:` / `xoffset:` (length or pair) — fine position adjustment
+- `right:` (string) — name of element where right bracket ends
+- `tr:` / `br:` — top-right / bottom-right label content
+
+---
+
+## Operator
+
+### `operator(op, name, margin)`
+Separate molecules within the same skeletize block. Resets drawing position.
+- `op:` (content, string, or none) — the displayed operator
+- `margin:` (length, default 1em) — spacing
+
+```typ
+operator($->$, margin: 1em)
+```
+
+---
+
+## Hook
+
+### `hook(name)`
+Named anchor point for links. Place at a position to create a connection target.
+
+---
+
+## Hide
+
+### `hide(bounds, body)`
+Visually suppress part of the drawing. Hidden elements still occupy bounding box space and remain linkable.
+- `bounds:` (bool, default true) — preserve bounding box when true
+
+---
+
+## Lewis structures
+
+### `lewis-single(angle, radius, offset, gap, stroke, fill)`
+Single electron dot. `offset:` is `"top"`, `"bottom"`, or `"center"`.
+
+### `lewis-double(angle, radius, gap, stroke, fill)`
+Two electron dots (lone pair).
+
+### `lewis-line(angle, length, stroke)`
+Line representing a shared electron pair.
+
+### `lewis-rectangle(angle, stroke, fill, height, width)`
+Rectangular lone pair marker.
+
+---
+
+## Configuration defaults
+
+```typ
+#let default = (
+  atom-sep: 3em,
+  fragment-margin: 0.2em,
+  fragment-font: none,
+  fragment-color: none,
+  link-over-radius: .2,
+  angle-increment: 45deg,
+  base-angle: 0deg,
+  debug: false,
+  single: (stroke: black),
+  double: (
+    gap: .25em,
+    offset: "center",
+    offset-coeff: 0.85,
+    stroke: black,
+  ),
+  triple: (
+    gap: .25em,
+    stroke: black,
+  ),
+  filled-cram: (
+    stroke: none,
+    fill: black,
+    base-length: .8em,
+  ),
+  dashed-cram: (
+    stroke: black + .05em,
+    dash-gap: .3em,
+    base-length: .8em,
+    tip-length: .1em,
+  ),
+  lewis: (
+    angle: 0deg,
+    radius: 0.2em,
+  ),
+  lewis-single: (
+    stroke: black,
+    fill: black,
+    radius: .1em,
+    gap: .25em,
+    offset: "top",
+  ),
+  lewis-double: (
+    stroke: black,
+    fill: black,
+    radius: .1em,
+    gap: .25em,
+  ),
+  lewis-line: (
+    stroke: black,
+    length: .7em,
+  ),
+  lewis-rectangle: (
+    stroke: .08em + black,
+    fill: white,
+    height: .7em,
+    width: .3em,
+  ),
+)
+```
+
+To override, pass only the keys you want to change to `skeletize()` or `skeletize-config()`.
+
+## Utility functions (exported from lib.typ)
+
+- `name` — the string `"alchemist"`
+- `transparent` — fully transparent color
+- `molecule(name:, links:, lewis:, vertical:, mol)` — deprecated alias for `fragment`
+
+## Touying bindings
+
+```typ
+#let touying-reducer-bindings = (
+  "reduce": ("skeletize",),
+  "cover": ("hide",)
+)
+```

--- a/.agents/skills/alchemist/references/patterns.md
+++ b/.agents/skills/alchemist/references/patterns.md
@@ -1,0 +1,223 @@
+# Alchemist Drawing Patterns
+
+This file lists common molecular drawing patterns you will frequently need.
+Adapt coordinates and angles to match your specific molecule.
+
+## 1. Basic alkane chain
+
+```typ
+#skeletize({
+  fragment("C_6H_14")
+})
+```
+
+## 2. Multi-atom chain with bonds
+
+```typ
+#skeletize({
+  fragment("C")
+  single()
+  fragment("C")
+  double()
+  fragment("O")
+  single()
+  fragment("H")
+})
+```
+
+## 3. Branched molecule (isopropyl example)
+
+```typ
+#skeletize({
+  fragment(name: "main", "C")
+  branch({
+    single(angle: 1)
+    fragment("C_2H_5")
+  })
+  branch({
+    single(angle: -1)
+    fragment("C_2H_5")
+  })
+  single()
+  fragment("OH")
+})
+```
+
+## 4. Benzene ring
+
+```typ
+#skeletize({
+  cycle(6, {
+    single()
+    fragment("")
+    double()
+    fragment("")
+    single()
+    fragment("")
+  })
+})
+```
+
+## 5. Cyclohexane with substituent
+
+```typ
+#skeletize({
+  cycle(6, {
+    single()
+    fragment("")
+    single()
+    fragment("")
+    single()
+    fragment("")
+  })
+  single(angle: 1)
+  fragment("OH")
+})
+```
+
+## 6. Lewis structure (water)
+
+```typ
+#skeletize({
+  fragment("O", lewis: (
+    lewis-single(offset: "top"),
+    lewis-single(offset: "bottom"),
+    lewis-double(angle: 90deg),
+    lewis-double(angle: -90deg),
+  ))
+  single()
+  fragment("H")
+  single()
+  fragment("H")
+})
+```
+
+## 7. Cross-linked fragments
+
+```typ
+#skeletize({
+  fragment(name: "A", "A")
+  single()
+  fragment("B")
+  branch({
+    single()
+    fragment(name: "X", "X")
+  })
+  single()
+  fragment("C", links: (
+    "A": single(),
+    "X": double(stroke: red),
+  ))
+})
+```
+
+## 8. Reaction scheme
+
+```typ
+#skeletize({
+  fragment("A")
+  operator($->$, margin: 1em)
+  fragment("B")
+  operator($<=>$, margin: 1em)
+  fragment("C")
+})
+```
+
+## 9. Polymer with brackets
+
+```typ
+#skeletize(config: (angle-increment: 30deg), {
+  parenthesis(
+    l: "[", r: "]",
+    br: $n$, {
+      single(angle: 1)
+      single(angle: -1)
+      single(angle: 1)
+    }
+  )
+})
+```
+
+## 10. Using hooks for complex connections
+
+```typ
+#skeletize({
+  fragment(name: "A", "A")
+  single()
+  hook(name: "h1")
+  single()
+  fragment("B")
+  single()
+  fragment(name: "C", "C", links: (
+    "h1": single(stroke: blue),
+  ))
+})
+```
+
+## 11. Resonance structures
+
+```typ
+#skeletize({
+  fragment("A")
+  parenthesis(resonance: true, {
+    single(angle: 1)
+    fragment("B")
+    single(angle: -1)
+    fragment("C")
+  })
+  operator($<->$, margin: 1.5em)
+  fragment("A")
+  parenthesis(resonance: true, {
+    single(angle: 1)
+    fragment("C")
+    single(angle: -1)
+    fragment("B")
+  })
+})
+```
+
+## 12. Vertical fragment layout
+
+```typ
+#skeletize({
+  fragment("ABCD", vertical: true)
+})
+```
+
+## 13. Fragment with custom colors
+
+```typ
+#skeletize({
+  fragment("ABCD", colors: (red, green, blue))
+  single()
+  fragment("EFGH", colors: (orange))
+})
+```
+
+## 14. CeTZ combined drawing
+
+```typ
+#skeletize({
+  import cetz.draw: *
+  double(absolute: 30deg, name: "l1")
+  single(absolute: -30deg, name: "l2")
+  fragment("X", name: "X")
+  hobby(
+    "l1.50%",
+    ("l1.start", 0.5, 90deg, "l1.end"),
+    "l1.start",
+    stroke: (paint: red, dash: "dashed"),
+    mark: (end: ">"),
+  )
+})
+```
+
+## 15. Using plus link between fragments
+
+```typ
+#skeletize({
+  fragment("Na")
+  plus()
+  fragment("Cl")
+})
+```

--- a/.agents/skills/alchemist/references/patterns.md
+++ b/.agents/skills/alchemist/references/patterns.md
@@ -29,7 +29,7 @@ Adapt coordinates and angles to match your specific molecule.
 
 ```typ
 #skeletize({
-  fragment(name: "main", "C")
+  fragment("C", name: "main")
   branch({
     single(angle: 1)
     fragment("C_2H_5")
@@ -96,12 +96,12 @@ Adapt coordinates and angles to match your specific molecule.
 
 ```typ
 #skeletize({
-  fragment(name: "A", "A")
+  fragment("A", name: "A")
   single()
   fragment("B")
   branch({
     single()
-    fragment(name: "X", "X")
+    fragment("X", name: "X")
   })
   single()
   fragment("C", links: (
@@ -127,13 +127,13 @@ Adapt coordinates and angles to match your specific molecule.
 
 ```typ
 #skeletize(config: (angle-increment: 30deg), {
-  parenthesis(
-    l: "[", r: "]",
-    br: $n$, {
+  parenthesis({
       single(angle: 1)
       single(angle: -1)
       single(angle: 1)
-    }
+    },
+    l: "[", r: "]",
+    br: $n$,
   )
 })
 ```
@@ -142,13 +142,13 @@ Adapt coordinates and angles to match your specific molecule.
 
 ```typ
 #skeletize({
-  fragment(name: "A", "A")
+  fragment("A", name: "A")
   single()
   hook(name: "h1")
   single()
   fragment("B")
   single()
-  fragment(name: "C", "C", links: (
+  fragment("C", name: "C", links: (
     "h1": single(stroke: blue),
   ))
 })


### PR DESCRIPTION
Closes #29

Adds a Codex skill at \.agents/skills/alchemist/\ to help AI assistants provide accurate guidance for drawing chemical skeletal formulas with the alchemist Typst package.

**Changes:**
- \.agents/skills/alchemist/SKILL.md\ — Complete usage guide for all alchemist features
- \.agents/skills/alchemist/agents/openai.yaml\ — Skill metadata for auto-discovery
- \.agents/skills/alchemist/references/api.md\ — Full API reference
- \.agents/skills/alchemist/references/patterns.md\ — 15 molecule drawing templates

The skill uses progressive disclosure: the SKILL.md covers the core workflow and points to reference files that load on demand when Codex needs deeper API details or ready-made patterns to adapt.